### PR TITLE
Add Pokémon list endpoint

### DIFF
--- a/src/website_handler.rs
+++ b/src/website_handler.rs
@@ -2,6 +2,8 @@ use std::fs;
 
 use crate::http::{Methods, Response};
 
+const FIRST_105_POKEMON_JSON: &str = r#"["bulbasaur","ivysaur","venusaur","charmander","charmeleon","charizard","squirtle","wartortle","blastoise","caterpie","metapod","butterfree","weedle","kakuna","beedrill","pidgey","pidgeotto","pidgeot","rattata","raticate","spearow","fearow","ekans","arbok","pikachu","raichu","sandshrew","sandslash","nidoran-f","nidorina","nidoqueen","nidoran-m","nidorino","nidoking","clefairy","clefable","vulpix","ninetales","jigglypuff","wigglytuff","zubat","golbat","oddish","gloom","vileplume","paras","parasect","venonat","venomoth","diglett","dugtrio","meowth","persian","psyduck","golduck","mankey","primeape","growlithe","arcanine","poliwag","poliwhirl","poliwrath","abra","kadabra","alakazam","machop","machoke","machamp","bellsprout","weepinbell","victreebel","tentacool","tentacruel","geodude","graveler","golem","ponyta","rapidash","slowpoke","slowbro","magnemite","magneton","farfetchd","doduo","dodrio","seel","dewgong","grimer","muk","shellder","cloyster","gastly","haunter","gengar","onix","drowzee","hypno","krabby","kingler","voltorb","electrode","exeggcute","exeggutor","cubone","marowak"]"#;
+
 use super::server::Handler;
 pub struct WebsiteHandler {
     public_folder_path: String,
@@ -38,6 +40,10 @@ impl Handler for WebsiteHandler {
                 "/hello" => Response::new(
                     crate::http::StatusCode::Ok,
                     Some("<h1> Hello world!</h1>".to_string()),
+                ),
+                "/pokemons" => Response::new(
+                    crate::http::StatusCode::Ok,
+                    Some(FIRST_105_POKEMON_JSON.to_string()),
                 ),
                 path => match self.read_file(path) {
                     Some(content) => Response::new(crate::http::StatusCode::Ok, Some(content)),


### PR DESCRIPTION
## Summary
- add a JSON list with the first 105 Pokémon
- expose new `/pokemons` GET endpoint that returns the list

## Testing
- `cargo build`
- `cargo run --quiet` *(manual smoke test)*